### PR TITLE
Allow social icons to wrap

### DIFF
--- a/modules/socials/layouts/partials/hb/modules/footer/modules/socials/index.html
+++ b/modules/socials/layouts/partials/hb/modules/footer/modules/socials/index.html
@@ -1,6 +1,6 @@
 {{- with .Site.Params.hb.footer.socials }}
   {{- $color := default true ._color }}
-  <div class="hb-footer-socials d-flex mb-2 justify-content-center">
+  <div class="hb-footer-socials d-flex mb-2 justify-content-center flex-wrap">
     {{- range $name, $id := . }}
       {{/* ignore options. */}}
       {{- if hasPrefix $name "_" }}


### PR DESCRIPTION
Currently on small screen, if there is multiple social icons in footer, they will go out of view. This patch allows the icons to wrap.

Old behaviour:
![2023-10-24-19-19-14-886-1088_firefox](https://github.com/hbstack/footer/assets/159569/7641bd45-591b-4b5e-a0dd-4a90cd54ba5c)

Patch:
![2023-10-24-19-19-46-423-1089_firefox](https://github.com/hbstack/footer/assets/159569/94c8864b-a44a-48f2-a724-ee244078d168)

